### PR TITLE
增加Skeleton处理错误全过程解决办法

### DIFF
--- a/bin/hyperf.php
+++ b/bin/hyperf.php
@@ -4,7 +4,6 @@
 error_reporting(0);
 function error_handle($error_level, $error_message, $error_file, $error_line)
 {
-    var_dump("错误级别：", $error_level);
     switch ($error_level) {
         # 提醒级别
         case E_NOTICE:

--- a/bin/hyperf.php
+++ b/bin/hyperf.php
@@ -1,10 +1,53 @@
 #!/usr/bin/env php
 <?php
+// 自定义处理 PHP 报错, 呈现错误发生的全过程（Swoole部分仍然只能捕获最后一次错误详情）
+error_reporting(0);
+function error_handle($error_level, $error_message, $error_file, $error_line)
+{
+    var_dump("错误级别：", $error_level);
+    switch ($error_level) {
+        # 提醒级别
+        case E_NOTICE:
+        case E_USER_NOTICE:
+            $error_type = "Notice ";
+            break;
+        # 警告级别
+        case E_WARNING:
+        case E_USER_WARNING:
+            $error_type = "WAINING";
+            break;
+        # 错误级别
+        case E_ERROR:
+        case E_USER_ERROR:
+        case E_RECOVERABLE_ERROR:
+            $error_type = "ERROR ";
+            break;
+        # 其他级别
+        default:
+            $error_type = "Unkown ";
+            break;
+    }
+    $lastError = PHP_EOL . date('Y-m-d H:i:s') . ", OcurredError,Type: {$error_type}, errorFile: {$error_file}, Line: {$error_line}, errorMessage: {$error_message}" . PHP_EOL;
+    var_dump($lastError);
+    $errorMsg = '';
+    foreach (debug_backtrace() as $key => $value) {
+        $errorMsg .= PHP_EOL . ($key + 1) . "\t" . json_encode($value, JSON_UNESCAPED_UNICODE) . PHP_EOL;
+    }
+    $format_error_msg = str_ireplace('\/', '/', $errorMsg);
+    var_dump("errorTrace：", $format_error_msg . PHP_EOL);
+    file_put_contents(BASE_PATH . '/runtime/logs/hyperf.log', $lastError . $format_error_msg, FILE_APPEND);
+}
 
-ini_set('display_errors', 'on');
-ini_set('display_startup_errors', 'on');
+set_error_handler('error_handle', E_ALL);
 
-error_reporting(E_ALL);
+function SwooleErrorHandle()
+{
+    $error = error_get_last();
+    var_dump("SwooleProcessOcurredError：", $error);
+}
+
+register_shutdown_function('SwooleErrorHandle');
+
 date_default_timezone_set('Asia/Shanghai');
 
 ! defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));

--- a/bin/hyperf.php
+++ b/bin/hyperf.php
@@ -43,7 +43,9 @@ set_error_handler('error_handle', E_ALL);
 function SwooleErrorHandle()
 {
     $error = error_get_last();
-    var_dump("SwooleProcessOcurredError：", $error);
+    if ($error) {
+        var_dump("SwooleProcessOcurredError：", $error);
+    }
 }
 
 register_shutdown_function('SwooleErrorHandle');

--- a/config/autoload/server.php
+++ b/config/autoload/server.php
@@ -31,6 +31,8 @@ return [
         'enable_coroutine' => true,
         'worker_num' => swoole_cpu_num(),
         'pid_file' => BASE_PATH . '/runtime/hyperf.pid',
+        'log_level' => 0,
+        'log_file' => BASE_PATH . 'runtime/logs/hyperf.log',
         'open_tcp_nodelay' => true,
         'max_coroutine' => 100000,
         'open_http2_protocol' => true,

--- a/config/autoload/server.php
+++ b/config/autoload/server.php
@@ -32,7 +32,7 @@ return [
         'worker_num' => swoole_cpu_num(),
         'pid_file' => BASE_PATH . '/runtime/hyperf.pid',
         'log_level' => 0,
-        'log_file' => BASE_PATH . 'runtime/logs/hyperf.log',
+        'log_file' => BASE_PATH . '/runtime/logs/hyperf.log',
         'open_tcp_nodelay' => true,
         'max_coroutine' => 100000,
         'open_http2_protocol' => true,


### PR DESCRIPTION
1.全局拦截PHP的错误处理机制，发生在PHP代码部分的错误会呈现整个错误生命周期。
2.Swoole部分依然只能呈现最后一次错误，无法呈现整个错误生命周期，Swoole官方没有解决整个错误生命周期的方案。Swoole不支持set_error_handler回调，只支持register_shutdown_function回调函数。