### PR TITLE
配置发送输出缓存区内存尺寸

### DIFF
--- a/config/autoload/server.php
+++ b/config/autoload/server.php
@@ -36,6 +36,7 @@ return [
         'open_http2_protocol' => true,
         'max_request' => 100000,
         'socket_buffer_size' => 2 * 1024 * 1024,
+        'buffer_output_size' => 2 * 1024 * 1024,
     ],
     'callbacks' => [
         SwooleEvent::ON_BEFORE_START => [Hyperf\Framework\Bootstrap\ServerStartCallback::class, 'beforeStart'],


### PR DESCRIPTION
对于超过buffer_output_size设置大小的response，这个值也得显性配置