### PR TITLE
Update databases.php

### DIFF
--- a/installer/resources/model_cache/databases.php
+++ b/installer/resources/model_cache/databases.php
@@ -14,6 +14,7 @@ return [
     'default' => [
         'driver' => env('DB_DRIVER', 'mysql'),
         'host' => env('DB_HOST', 'localhost'),
+        'port' => env('DB_PORT', 3306),
         'database' => env('DB_DATABASE', 'hyperf'),
         'username' => env('DB_USERNAME', 'root'),
         'password' => env('DB_PASSWORD', ''),
@@ -37,7 +38,7 @@ return [
             'load_script' => true,
         ],
         'commands' => [
-            'db:model' => [
+            'gen:model' => [
                 'path' => 'app/Model',
                 'force_casts' => true,
                 'inheritance' => 'Model',


### PR DESCRIPTION
安装时启用 model_cache时会覆盖config/autoload/databases.php文件，导致port与gen:model丢失问题