### PR TITLE
解决 composer start 启动项目时的 超时问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,9 @@
         "test": "co-phpunit -c phpunit.xml --colors=always",
         "cs-fix": "php-cs-fixer fix $1",
         "analyse": "phpstan analyse --memory-limit 300M -l 0 -c phpstan.neon ./app ./config",
-        "start": "php ./bin/hyperf.php start"
+        "start": [
+          "Composer\\Config::disableProcessTimeout",
+          "php ./bin/hyperf.php start"
+        ]
     }
 }


### PR DESCRIPTION
默认Composer 的scripts 运行时间默认是会出现超时问题的