### PR TITLE
Remove `composer.lock` from `.gitignore` after creating project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor/
 .DS_Store
 .phpunit*
 *.cache
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ vendor/
 .phpintel/
 .env
 .DS_Store
-*.lock
 .phpunit*
 *.cache


### PR DESCRIPTION
针对具体项目 composer.lock 还是需要提交到版本库里管理的，但是对于 skeleton 确实不应该有这个 lock，就好像类库，所以不建议放在 .gitignore 里。