### PR TITLE
App run in coroutine for test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "description": "A coroutine framework that focuses on hyperspeed and flexible, specifically use for build microservices and middlewares.",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "hyperf/cache": "~2.1.0",
         "hyperf/command": "~2.1.0",
         "hyperf/config": "~2.1.0",

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -26,4 +26,4 @@ Hyperf\Di\ClassLoader::init();
 
 $container = require BASE_PATH . '/config/container.php';
 
-$container->get(Hyperf\Contract\ApplicationInterface::class);
+\Swoole\Coroutine\run(fn() => $container->get(Hyperf\Contract\ApplicationInterface::class));


### PR DESCRIPTION
在hyper2.2中，测试命令必须带‘--prepend test/bootstrap.php’选项，会优先加载此文件。如果项目中监听了app启动事件并使用的swoole协程中的api会出现错误，而2.2之前版本是运行在协程环境中的。