### PR TITLE
Set `APP_ENV` to `testing` when running tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,7 @@
             <directory suffix=".php">./app</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="APP_ENV" value="testing" force="true"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
We should use the testing  as `APP_ENV` when running tests.
