### PR TITLE
Update HttpTestCase.php

### DIFF
--- a/test/HttpTestCase.php
+++ b/test/HttpTestCase.php
@@ -15,6 +15,8 @@ namespace HyperfTest;
 use Hyperf\Testing\Client;
 use PHPUnit\Framework\TestCase;
 
+use function Hyperf\Support\make;
+
 /**
  * Class HttpTestCase.
  * @method get($uri, $data = [], $headers = [])


### PR DESCRIPTION
ExampleTest 继承的类已经变成了Hyperf\Testing\TestCase，HttpTestCase.php文件甚至可以删除了。