### PR TITLE
refactor(server): Use `SWOOLE_BASE`

### DIFF
--- a/config/autoload/server.php
+++ b/config/autoload/server.php
@@ -14,7 +14,7 @@ use Hyperf\Server\Server;
 use Swoole\Constant;
 
 return [
-    'mode' => SWOOLE_PROCESS,
+    'mode' => SWOOLE_BASE,
     'servers' => [
         [
             'name' => 'http',


### PR DESCRIPTION
Use `SWOOLE_BASE` as the default server mode right from the template.

It is Swoole's default since 5.0 and has been receiving a lot of enhances, especially related to memory,
https://github.com/swoole/swoole-src/releases?q=base&expanded=true