### PR TITLE
Add migrations and seeders file when building image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@
 !app/
 !bin/
 !config/
+!migrations/
+!seeders/
 !composer.*


### PR DESCRIPTION
Currently, HyperF doesn't add `migrations` and `seeders` folder to docker building context, so they won't appear in the final image