### PR TITLE
fix: remove parentheses from ENV in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG timezone
 
 ENV TIMEZONE=${timezone:-"Asia/Shanghai"} \
     APP_ENV=prod \
-    SCAN_CACHEABLE=(true)
+    SCAN_CACHEABLE=true
 
 # update
 RUN set -ex \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,7 +18,7 @@ ARG GID=1000
 
 ENV TIMEZONE=${timezone:-"Asia/Shanghai"} \
     APP_ENV=dev \
-    SCAN_CACHEABLE=(false)
+    SCAN_CACHEABLE=false
 
 # Make local user to avoid file permissions on runtime
 RUN addgroup -g ${GID} application && \


### PR DESCRIPTION
remove parentheses from ENV in Dockerfile to prevent string literal parsing
`➜  hyperf-test docker build -t hyperftest:v1.0.1 . `
`➜  hyperf-test docker run --rm --entrypoint php hyperftest:v1.0.1 -r "var_dump(getenv('SCAN_CACHEABLE'));"`
`string(6) "(true)"`

```
Router::addRoute(['GET', 'POST', 'HEAD'], '/', function () {
    return [
        'method' => 'GET',
        'message' => 'Checking environment variable',
        // Мы возвращаем и тип, и значение
        'scan_cacheable_raw' => getenv('SCAN_CACHEABLE'),
        'scan_cacheable_type' => gettype(getenv('SCAN_CACHEABLE')),
    ];
});
```
`{"method":"GET","message":"Checking environment variable","scan_cacheable_raw":"(false)","scan_cacheable_type":"string"}`